### PR TITLE
removed character escaping when dumping json

### DIFF
--- a/json_reindent.py
+++ b/json_reindent.py
@@ -50,7 +50,8 @@ class JsonReindentCommand(TextCommand):
                     json_data,
                     indent=self.view.settings().get("tab_size", 2),
                     separators=(',', ': '),
-                    sort_keys=settings.get('sort_keys') is True
+                    sort_keys=settings.get('sort_keys') is True,
+                    ensure_ascii=False
                 )
             )
 


### PR DESCRIPTION
This solves Issue #4 (hopefully not breaking anything else :-) .

``` json
{ "something": [ { "stuff": "Καλημέρα" } ] }
```

now becomes

``` json
{
   "something": [
      {
         "stuff": "Καλημέρα"
      }
   ]
}
```
